### PR TITLE
Ignored warnings for invalid files in attachments

### DIFF
--- a/src/Yandex/Allure/Adapter/Event/AddAttachmentEvent.php
+++ b/src/Yandex/Allure/Adapter/Event/AddAttachmentEvent.php
@@ -40,7 +40,7 @@ class AddAttachmentEvent implements StepEvent
     public function getAttachmentFileName($filePathOrContents, $type)
     {
         $filePath = $filePathOrContents;
-        if (!file_exists($filePath) || !is_file($filePath)) {
+        if (!@file_exists($filePath) || !@is_file($filePath)) {
             //Save contents to temporary file
             $filePath = tempnam(sys_get_temp_dir(), 'allure-attachment');
             if (!file_put_contents($filePath, $filePathOrContents)) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-31453

After this PR:
when an attachment that is not a file is added then the code does not throw a warning but handles it as it's supposed to.

There should be no warning as it is a feature of Allure - adding attachments that are not in the filesystem.